### PR TITLE
Remove old installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ A honeypot for the Log4Shell vulnerability (CVE-2021-44228).
 
 ## Usage
 
-1. Install Poetry: `curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -`
-2. Fetch this GitHub repository `git clone https://github.com/thomaspatzke/Log4Pot.git`
-3. Change directory into the local copy with `cd Log4Pot`
-4. Install dependencies: `poetry install`
-5. Put parameters into log4pot.conf.
-6. Run: `poetry run python log4pot.py @log4pot.conf`
+1. Install PIP: `sudo apt install python3-pip`
+2. Install Azure: `sudo apt install azure`
+3. Install Poetry: `sudo pip3 install poetry`
+4. Fetch this GitHub repository `git clone https://github.com/thomaspatzke/Log4Pot.git`
+5. Change directory into the local copy with `cd Log4Pot`
+6. Install dependencies: `sudo poetry install`
+7. Put parameters into log4pot.conf.
+8. Run: `sudo poetry run python log4pot.py @log4pot.conf`
 
 Alternatively, you can also run log4pot without external dependencies:
 ```


### PR DESCRIPTION
Hello,

I removed the deprecated installer for poetry as mentionned in their documentation and added the pyp alternative.
Also added the sudo for some cases as well as the azure package that was missing when I tried to launch the script.